### PR TITLE
Add a relative option to pulse_width_accumulate

### DIFF
--- a/esphome/components/pulse_width_accumulate/pulse_width_accumulate.cpp
+++ b/esphome/components/pulse_width_accumulate/pulse_width_accumulate.cpp
@@ -110,6 +110,16 @@ void PulseWidthAccumulateSensor::update() {
              this->rejection_threshold_);
     cumulative_width = 0.0f;
   }
+
+  // Calculate relative pulse width if relative mode is enabled
+  if (this->relative_mode_) {
+    cumulative_width = cumulative_width / polling_interval_s;  // Normalize to 0..1
+    if (cumulative_width > 1.0f) {
+      ESP_LOGW(TAG, "Relative pulse width exceeds 1.0: %.3f", cumulative_width);
+      cumulative_width = 1.0f;  // Clamp to 1.0 if it exceeds
+    }
+  }
+
   // get frequency if needed
   if (this->frequency_sensor_ != nullptr) {
     float pulse_count = this->store_.get_pulses_this_cycle();

--- a/esphome/components/pulse_width_accumulate/pulse_width_accumulate.h
+++ b/esphome/components/pulse_width_accumulate/pulse_width_accumulate.h
@@ -34,12 +34,14 @@ class PulseWidthAccumulateSensor : public sensor::Sensor, public PollingComponen
   float get_setup_priority() const override { return setup_priority::DATA; }
   void update();
   void set_frequency_sensor(sensor::Sensor *frequency_sensor) { frequency_sensor_ = frequency_sensor; }
+  void set_relative_mode(bool relative) { relative_mode_ = relative; }
 
  private:
   float rejection_threshold_{1000.0f};
   PulseWidthAccumulateSensorStore store_;
   InternalGPIOPin *pin_;
   sensor::Sensor *frequency_sensor_{nullptr};
+  bool relative_mode_{false};
 };
 }  // namespace pulse_width_accumulate
 }  // namespace esphome

--- a/esphome/components/pulse_width_accumulate/sensor.py
+++ b/esphome/components/pulse_width_accumulate/sensor.py
@@ -59,7 +59,12 @@ async def to_code(config):
     # Pass the relative option to the C++ code
     if config[CONF_RELATIVE]:
         cg.add(var.set_relative_mode(True))
-        cg.add(var.set_unit_of_measurement("%"))
-        cg.add(var.set_icon(ICON_TIMER))
-        cg.add(var.set_accuracy_decimals(1))
-        cg.add(var.set_state_class(cg.RawExpression("esphome::sensor::STATE_CLASS_MEASUREMENT")))
+        # Only set defaults if the user hasn't overridden them
+        if "unit_of_measurement" not in config:
+            cg.add(var.set_unit_of_measurement("%"))
+        if "icon" not in config:
+            cg.add(var.set_icon(ICON_TIMER))
+        if "accuracy_decimals" not in config:
+            cg.add(var.set_accuracy_decimals(1))
+        if "state_class" not in config:
+            cg.add(var.set_state_class(cg.RawExpression("esphome::sensor::STATE_CLASS_MEASUREMENT")))

--- a/esphome/components/pulse_width_accumulate/sensor.py
+++ b/esphome/components/pulse_width_accumulate/sensor.py
@@ -13,6 +13,8 @@ from esphome.const import (
     UNIT_HERTZ,
 )
 
+CONF_RELATIVE = "relative"
+
 pulse_width_ns = cg.esphome_ns.namespace("pulse_width_accumulate")
 
 PulseWidthAccumulateSensor = pulse_width_ns.class_(
@@ -36,6 +38,7 @@ CONFIG_SCHEMA = (
                 icon=ICON_PULSE,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
+            cv.Optional(CONF_RELATIVE, default=False): cv.boolean,
         }
     )
     .extend(cv.polling_component_schema("60s"))
@@ -53,3 +56,6 @@ async def to_code(config):
     if conf_freq := config.get(CONF_FREQUENCY):
         sens = await sensor.new_sensor(conf_freq)
         cg.add(var.set_frequency_sensor(sens))
+    # Pass the relative option to the C++ code
+    if config[CONF_RELATIVE]:
+        cg.add(var.set_relative_mode(True))

--- a/esphome/components/pulse_width_accumulate/sensor.py
+++ b/esphome/components/pulse_width_accumulate/sensor.py
@@ -59,3 +59,7 @@ async def to_code(config):
     # Pass the relative option to the C++ code
     if config[CONF_RELATIVE]:
         cg.add(var.set_relative_mode(True))
+        cg.add(var.set_unit_of_measurement("%"))
+        cg.add(var.set_icon(ICON_TIMER))
+        cg.add(var.set_accuracy_decimals(1))
+        cg.add(var.set_state_class(cg.RawExpression("esphome::sensor::STATE_CLASS_MEASUREMENT")))


### PR DESCRIPTION
# What does this implement/fix?

This adds the "relative" boolean option to the pulse_width_accumulate sensor. Enabling this changes the unit of measurement to %, the state class to STATE_CLASS_MEASUREMENT and, most importantly, publishes the quotient of the accumulated pulse width relative to the update_interval instead of the absolute time in seconds. Helpful e.g. for sensors whose value equivalent to the time the pulse is high during them measurement interval, e.g. PM1003PH PM2.5 sensor (see example below). 

If you need the percentage from 0-100% instead of a quotient from 0-1, simply add 
```yaml
filters: 
  - multiply: 100
```
to your configs. 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other


## Example entry for `config.yaml`:

```yaml
# Example config.yaml for pm1003ph
sensor:
  - platform: pulse_width_accumulate
    pin: 
      number: GPIO4
      inverted: true
    id: pm1003ph_pulse_width
    name: "PM1003PH Pulse Width Meter"
    relative: true
    update_interval: 15s
    accuracy_decimals: 2
    unit_of_measurement: "µg/m³"
    device_class: "pm25"
    icon: "mdi:blur"
    filters:
      - sliding_window_moving_average:
          window_size: 4 
          send_every: 1
      - multiply: 100
```

## Checklist:
  - [X] The code change is tested and works locally.
