### PR TITLE
Make lower threshold time configurable

### DIFF
--- a/esphome/components/pulse_width_accumulate/pulse_width_accumulate.cpp
+++ b/esphome/components/pulse_width_accumulate/pulse_width_accumulate.cpp
@@ -88,13 +88,17 @@ void IRAM_ATTR PulseWidthAccumulateSensorStore::gpio_intr(PulseWidthAccumulateSe
     if (pulse_width_us > LOWER_PULSE_WIDTH_THRESHOLD) {
       arg->cumulative_width_us_ += pulse_width_us;
       arg->pulse_count_ += 1;
-    } else {
+    }
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
+     else {
       arg->pulse_skip_count_ += 1;  // count the number of pulses that are too short
     }
+#endif
   }
   portEXIT_CRITICAL_ISR(&arg->mux_);
 }
 
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
 uint32_t PulseWidthAccumulateSensorStore::get_pulse_skip_count() {
   uint32_t pulse_skip_count = 0;
   // Safely copy & reset the pulse skip counter
@@ -104,6 +108,7 @@ uint32_t PulseWidthAccumulateSensorStore::get_pulse_skip_count() {
   portEXIT_CRITICAL(&this->mux_);
   return pulse_skip_count;
 }
+#endif
 
 void PulseWidthAccumulateSensor::dump_config() {
   LOG_SENSOR("", "Pulse Width", this)
@@ -145,10 +150,12 @@ void PulseWidthAccumulateSensor::update() {
     this->frequency_sensor_->publish_state(frequency);
   }
 
+  #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
   int skipped_count = this->store_.get_pulse_skip_count();
   if (skipped_count > 0) {
     ESP_LOGV(TAG, "Pulses skipped (< %dus): %d", LOWER_PULSE_WIDTH_THRESHOLD_VALUE, skipped_count);
   }
+  #endif
 
   this->publish_state(cumulative_width);
 }

--- a/esphome/components/pulse_width_accumulate/pulse_width_accumulate.cpp
+++ b/esphome/components/pulse_width_accumulate/pulse_width_accumulate.cpp
@@ -3,10 +3,14 @@
 #include <freertos/FreeRTOS.h>
 #include <freertos/semphr.h>
 
+#ifndef LOWER_PULSE_WIDTH_THRESHOLD_VALUE
+#define LOWER_PULSE_WIDTH_THRESHOLD_VALUE 17  // Default value
+#endif
+
 namespace esphome {
 namespace pulse_width_accumulate {
 static const char *const TAG = "pulse_width";
-constexpr uint32_t LOWER_PULSE_WIDTH_THRESHOLD = 17;  // pulses shorter than this will be dropped
+constexpr uint32_t LOWER_PULSE_WIDTH_THRESHOLD = LOWER_PULSE_WIDTH_THRESHOLD_VALUE;  // pulses shorter than this will be dropped
 constexpr uint32_t DISSECTION_THRESHOLD =
     4.9e5L;  // longer pulses disected during polling.  0.49 seconds works okay for polling periods >=1s
 PulseWidthAccumulateSensorStore::PulseWidthAccumulateSensorStore() { mux_ = portMUX_INITIALIZER_UNLOCKED; }
@@ -84,15 +88,29 @@ void IRAM_ATTR PulseWidthAccumulateSensorStore::gpio_intr(PulseWidthAccumulateSe
     if (pulse_width_us > LOWER_PULSE_WIDTH_THRESHOLD) {
       arg->cumulative_width_us_ += pulse_width_us;
       arg->pulse_count_ += 1;
+    } else {
+      arg->pulse_skip_count_ += 1;  // count the number of pulses that are too short
     }
   }
   portEXIT_CRITICAL_ISR(&arg->mux_);
+}
+
+uint32_t PulseWidthAccumulateSensorStore::get_pulse_skip_count() {
+  uint32_t pulse_skip_count = 0;
+  // Safely copy & reset the pulse skip counter
+  portENTER_CRITICAL(&this->mux_);
+  pulse_skip_count = this->pulse_skip_count_;
+  this->pulse_skip_count_ = 0;
+  portEXIT_CRITICAL(&this->mux_);
+  return pulse_skip_count;
 }
 
 void PulseWidthAccumulateSensor::dump_config() {
   LOG_SENSOR("", "Pulse Width", this)
   LOG_UPDATE_INTERVAL(this)
   LOG_PIN("  Pin: ", this->pin_);
+  ESP_LOGCONFIG(TAG, "  Lower pulse width threshold in us: %d", LOWER_PULSE_WIDTH_THRESHOLD_VALUE);
+  ESP_LOGCONFIG(TAG, "  Relative mode: %s", this->relative_mode_ ? "YES" : "NO");
 }
 
 void PulseWidthAccumulateSensor::update() {
@@ -126,6 +144,12 @@ void PulseWidthAccumulateSensor::update() {
     float frequency = pulse_count / polling_interval_s;
     this->frequency_sensor_->publish_state(frequency);
   }
+
+  int skipped_count = this->store_.get_pulse_skip_count();
+  if (skipped_count > 0) {
+    ESP_LOGV(TAG, "Pulses skipped (< %dus): %d", LOWER_PULSE_WIDTH_THRESHOLD_VALUE, skipped_count);
+  }
+
   this->publish_state(cumulative_width);
 }
 

--- a/esphome/components/pulse_width_accumulate/pulse_width_accumulate.h
+++ b/esphome/components/pulse_width_accumulate/pulse_width_accumulate.h
@@ -14,7 +14,9 @@ class PulseWidthAccumulateSensorStore {
   void setup(InternalGPIOPin *pin);
   static void gpio_intr(PulseWidthAccumulateSensorStore *arg);
   float get_pulses_this_cycle();
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
   uint32_t get_pulse_skip_count();
+#endif
   float get_cumulative_pulse_width_s();
 
  private:
@@ -24,7 +26,9 @@ class PulseWidthAccumulateSensorStore {
   uint32_t cumulative_width_us_{0};
   float cumulative_width_s_{0.0f};
   uint32_t pulse_count_{0};
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
   uint32_t pulse_skip_count_{0};
+#endif
   portMUX_TYPE mux_;
 };
 

--- a/esphome/components/pulse_width_accumulate/pulse_width_accumulate.h
+++ b/esphome/components/pulse_width_accumulate/pulse_width_accumulate.h
@@ -14,6 +14,7 @@ class PulseWidthAccumulateSensorStore {
   void setup(InternalGPIOPin *pin);
   static void gpio_intr(PulseWidthAccumulateSensorStore *arg);
   float get_pulses_this_cycle();
+  uint32_t get_pulse_skip_count();
   float get_cumulative_pulse_width_s();
 
  private:
@@ -23,6 +24,7 @@ class PulseWidthAccumulateSensorStore {
   uint32_t cumulative_width_us_{0};
   float cumulative_width_s_{0.0f};
   uint32_t pulse_count_{0};
+  uint32_t pulse_skip_count_{0};
   portMUX_TYPE mux_;
 };
 

--- a/esphome/components/pulse_width_accumulate/sensor.py
+++ b/esphome/components/pulse_width_accumulate/sensor.py
@@ -14,6 +14,7 @@ from esphome.const import (
 )
 
 CONF_RELATIVE = "relative"
+CONF_LOWER_THRESHOLD = "lower_threshold_us"
 
 pulse_width_ns = cg.esphome_ns.namespace("pulse_width_accumulate")
 
@@ -39,6 +40,7 @@ CONFIG_SCHEMA = (
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
             cv.Optional(CONF_RELATIVE, default=False): cv.boolean,
+            cv.Optional(CONF_LOWER_THRESHOLD, default=17): cv.int_range(17, 10000),
         }
     )
     .extend(cv.polling_component_schema("60s"))
@@ -56,6 +58,9 @@ async def to_code(config):
     if conf_freq := config.get(CONF_FREQUENCY):
         sens = await sensor.new_sensor(conf_freq)
         cg.add(var.set_frequency_sensor(sens))
+    # Register the lower threshold if configured
+    if CONF_LOWER_THRESHOLD in config:
+        cg.add_define("LOWER_PULSE_WIDTH_THRESHOLD_VALUE", config[CONF_LOWER_THRESHOLD])
     # Pass the relative option to the C++ code
     if config[CONF_RELATIVE]:
         cg.add(var.set_relative_mode(True))


### PR DESCRIPTION
# What does this implement/fix?

For my sensor, I know the smallest PWM pulse it sends will be ~1ms. Hence, to circumvent any noise, I want to set the LOWER_PULSE_WIDTH_THRESHOLD to e.g. 900us. 

To not impact runtime behaviour, I added a #define for that that the configuration option ```lower_threshold_us``` sets in the source code.

For debugging purposes, I've added a counter pulse_skip_count_ and corresponding get_pulse_skip_count() method and debugging output, but hid it behind a preprocessor check that only enables the code when LOG_LEVEL is VERBOSE or higher, so it only impacts the runtime if the information is actually wanted by the user.

Feel free to ignore if you think this is too complicated. Works for me(tm) for both VERBOSE and lower logging levels, also deliberatly set the threshold to 10ms/10000us to see if the skipped pulses were actually counted and logged, which they were.

Also, updated dump_config() to dump the new configuration variables as well.


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other
